### PR TITLE
Don't log password if passed in via RABBITMQ_PASS

### DIFF
--- a/set_rabbitmq_password.sh
+++ b/set_rabbitmq_password.sh
@@ -21,7 +21,14 @@ touch /.rabbitmq_password_set
 echo "========================================================================"
 echo "You can now connect to this RabbitMQ server using, for example:"
 echo ""
-echo "    curl --user $USER:$PASS http://<host>:<port>/api/vhosts"
-echo ""
-echo "Please remember to change the above password as soon as possible!"
+
+if [ ${_word} == "random" ]; then
+    echo "    curl --user $USER:$PASS http://<host>:<port>/api/vhosts"
+    echo ""
+    echo "Please remember to change the above password as soon as possible!"
+else
+    echo "    curl --user $USER:<RABBITMQ_PASS> http://<host>:<port>/api/vhosts"
+    echo ""
+fi
+
 echo "========================================================================"


### PR DESCRIPTION
It seems silly that when I generate a new, secure password, set it via the environment variable, and then run this rabbitmq container, it immediately logs the admin password and then tells me to change it. 

Is there an inherent reason that the default pass should already be considered compromised or something? (I'm not actually too familiar with rabbitmq).

If not, this PR will stop logging the password if you pass it in via RABBITMQ_PASS